### PR TITLE
ignore mmx and sse  and enable neon and simd for raspberry pi

### DIFF
--- a/files.xml
+++ b/files.xml
@@ -3,7 +3,7 @@
 	<!-- TODO: ARM64 NEON -->
 
 	<set name="PIXMAN_ARM_SIMD" value="1" if="android" unless="HXCPP_ARMV7 || HXCPP_ARMV7S || HXCPP_ARM64 || HXCPP_X86" />
-	<set name="PIXMAN_ARM_NEON" value="1" if="HXCPP_ARMV7 || HXCPP_ARMV7S" unless="ios" />
+	<set name="PIXMAN_ARM_NEON" value="1" if="HXCPP_ARMV7 || HXCPP_ARMV7S || rpi" unless="ios" />
 
 	<files id="native-toolkit-pixman" >
 
@@ -19,8 +19,8 @@
 
 		<compilerflag value="-I${ANDROID_NDK_ROOT}/sources/android/cpufeatures" if="android"/>
 
-		<compilerflag value="-msse3" if="linux || mac" />
-		<compilerflag value="-mssse3" if="linux || mac" />
+		<compilerflag value="-msse3" if="linux || mac" unless="rpi"/>
+		<compilerflag value="-mssse3" if="linux || mac" unless="rpi"/>
 
 		<compilerflag value="-Wno-attributes" if="android" />
 		<compilerflag value="-Wno-tautological-constant-out-of-range-compare" if="mac || ios || tvos" />
@@ -51,15 +51,15 @@
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-linear-gradient.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-matrix.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-mips.c" />
-		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-mmx.c" if="windows || mac || linux" />
+		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-mmx.c" if="windows || mac || linux" unless="rpi"/>
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-noop.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-ppc.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-radial-gradient.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-region16.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-region32.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-solid-fill.c" />
-		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-sse2.c" if="windows || mac || linux" />
-		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-ssse3.c" if="windows || mac || linux" />
+		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-sse2.c" if="windows || mac || linux" unless="rpi"/>
+		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-ssse3.c" if="windows || mac || linux" unless="rpi"/>
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-timer.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-trap.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/pixman/src/pixman-utils.c" />

--- a/files.xml
+++ b/files.xml
@@ -2,7 +2,7 @@
 
 	<!-- TODO: ARM64 NEON -->
 
-	<set name="PIXMAN_ARM_SIMD" value="1" if="android" unless="HXCPP_ARMV7 || HXCPP_ARMV7S || HXCPP_ARM64 || HXCPP_X86" />
+	<set name="PIXMAN_ARM_SIMD" value="1" if="android || rpi" unless="HXCPP_ARMV7 || HXCPP_ARMV7S || HXCPP_ARM64 || HXCPP_X86" />
 	<set name="PIXMAN_ARM_NEON" value="1" if="HXCPP_ARMV7 || HXCPP_ARMV7S || rpi" unless="ios" />
 
 	<files id="native-toolkit-pixman" >

--- a/src/config.h
+++ b/src/config.h
@@ -266,14 +266,14 @@
 /* #undef USE_OPENMP */
 
 /* use SSE2 compiler intrinsics */
-#if defined(HX_WINDOWS) || defined(HX_MACOS) || defined(HX_LINUX)
+#if defined(HX_WINDOWS) || defined(HX_MACOS) || (defined(HX_LINUX) && !defined(RASPBERRYPI))
 #define USE_SSE2 1
 #else
 /* #undef USE_SSE2 */
 #endif
 
 /* use SSSE3 compiler intrinsics */
-#if defined(HX_WINDOWS) || defined(HX_MACOS) || defined(HX_LINUX)
+#if defined(HX_WINDOWS) || defined(HX_MACOS) || (defined(HX_LINUX) && !defined(RASPBERRYPI))
 #define USE_SSE3 1
 #else
 /* #undef USE_SSE3 */
@@ -283,7 +283,7 @@
 /* #undef USE_VMX */
 
 /* use x86 MMX compiler intrinsics */
-#if (defined(HX_WINDOWS) || /*defined(HX_MACOS) ||*/ defined(HX_LINUX)) && !defined(HXCPP_M64)
+#if (defined(HX_WINDOWS) || /*defined(HX_MACOS) ||*/ (defined(HX_LINUX) && !defined(RASPBERRYPI)) ) && !defined(HXCPP_M64)
 #define USE_X86_MMX 1
 #else
 /* #undef USE_X86_MMX */


### PR DESCRIPTION
These commits add 'unless' conditionals for rpi for mmx and sse.
Also NEON and SIMD are enabled in files.xml although I'm not sure that really does something.
DEFINES for SSE and MMX  are ignored through a **!defined(RASPBERRYPI)**
Tested on the Raspberry Pi 3.